### PR TITLE
fix: commonjs export

### DIFF
--- a/src/angular-translate-loader-pluggable.js
+++ b/src/angular-translate-loader-pluggable.js
@@ -67,7 +67,7 @@ function translatePluggableLoaderProvider() {
 }
 
 // commonjs export
-if (typeof exports !== 'undefined') {
+if (typeof exports !== 'undefined' && module && typeof module.exports === "object") {
   module.exports = {
     name: moduleName
   };


### PR DESCRIPTION
Added additional logic to avoid populate the global scope with a module.exports variable.