### PR TITLE
Soft failure for each loader

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,5 +17,8 @@
     "bower_components",
     "test",
     "tests"
-  ]
+  ],
+  "dependencies": {
+    "angular-promise-extras": "^0.1.8"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/juristr/angular-translate-loader-pluggable.git"
+  },
+  "dependencies": {
+    "angular-promise-extras": "^0.1.8"
   }
 }

--- a/src/angular-translate-loader-pluggable.ts
+++ b/src/angular-translate-loader-pluggable.ts
@@ -4,7 +4,8 @@ const moduleName = 'angular-translate-loader-pluggable';
 
 angular
   .module(moduleName, [
-    'pascalprecht.translate'
+    'pascalprecht.translate',
+    'ngPromiseExtras'
   ])
   .provider('translatePluggableLoader', translatePluggableLoaderProvider);
 
@@ -51,12 +52,14 @@ function translatePluggableLoaderProvider(): any {
         loaderInstances.push(loaderPromise);
       }
 
-      $q.all(loaderInstances)
+      $q.allSettled(loaderInstances)
         .then(function (loaders) {
           let result;
 
           for (let i = 0; i < loaders.length; i++) {
-            result = angular.extend({}, result, loaders[i]);
+            if(loaders[i].state === 'fulfilled') {
+              result = angular.extend({}, result, loaders[i].value);
+            }
           }
 
           deferred.resolve(result);


### PR DESCRIPTION
Using [angular-promise-extras](https://github.com/ohjames/angular-promise-extras), and `$q.allSettled` logic. This allow promises concurency without rejecting main promise. We then gather the `state` of each promise, and merge translation stuff only if resolved. Every rejected promise error is "digested", but still naturally logs to console for now. I didn't follow contribution guidelines because I don't have time for now.

Resolves #7