### PR TITLE
Fix for "Tried to load angular more than once"

### DIFF
--- a/src/angular-translate-loader-pluggable.ts
+++ b/src/angular-translate-loader-pluggable.ts
@@ -1,5 +1,3 @@
-import * as angular from 'angular';
-
 const moduleName = 'angular-translate-loader-pluggable';
 
 angular


### PR DESCRIPTION
As discussed in our recent email exchange, I've removed the line
`import * as angular from 'angular’;`
to stop the warning
**WARNING: Tried to load angular more than once.**
being displayed in the browser console.